### PR TITLE
Switch to Python 3 for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: sync-conf-files
         name: Update when configuration files change
-        entry: python tools/sync_conf_files.py ./
+        entry: python3 tools/sync_conf_files.py ./
         language: system
         files: '.*ESP_Panel_(Board_Custom|Board_Supported|Conf)\.h'
 
@@ -47,6 +47,6 @@ repos:
     hooks:
       - id: check-file-versions
         name: Update when versions change
-        entry: python tools/check_file_version.py ./
+        entry: python3 tools/check_file_version.py ./
         language: system
         files: '(.*ESP_Panel_(Board_Custom|Board_Supported|Conf)\.h|library.properties|.*ESP_PanelVersions.h)'


### PR DESCRIPTION
Switch to Python 3 for pre-commit to make it work with Ubuntu. Otherwise:

```
user@Matter:~/Documents/ESP32_Display_Panel$ pre-commit run --all-files
astyle formatter.........................................................Passed
Check copyright notices..................................................Passed
flake8...................................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
mixed line ending........................................................Passed
Update when configuration files change...................................Failed
- hook id: sync-conf-files
- exit code: 1

Executable `python` not found

Update when versions change..............................................Failed
- hook id: check-file-versions
- exit code: 1

Executable `python` not found
```
