### PR TITLE
Fix `LVGL_PORT_ROTATION_DEGREE` issue

### DIFF
--- a/examples/SquareLine/v8/WiFiClock/lvgl_port_v8.cpp
+++ b/examples/SquareLine/v8/WiFiClock/lvgl_port_v8.cpp
@@ -485,8 +485,8 @@ static lv_disp_t *display_init(ESP_PanelLcd *lcd)
     ESP_LOGD(TAG, "Register display driver to LVGL");
     lv_disp_drv_init(&disp_drv);
     disp_drv.flush_cb = flush_callback;
-    if (LVGL_PORT_ROTATION_DEGREE == 90) || (LVGL_PORT_ROTATION_DEGREE == 270)
-        disp_drv.hor_res = LVGL_PORT_DISP_HEIGHT;
+#if (LVGL_PORT_ROTATION_DEGREE == 90) || (LVGL_PORT_ROTATION_DEGREE == 270)
+    disp_drv.hor_res = LVGL_PORT_DISP_HEIGHT;
     disp_drv.ver_res = LVGL_PORT_DISP_WIDTH;
 #else
     disp_drv.hor_res = LVGL_PORT_DISP_WIDTH;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_Display_Panel
-version=0.1.5
+version=0.1.6
 author=espressif
 maintainer=espressif
 sentence=ESP32_Display_Panel is an Arduino library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.

--- a/src/ESP_PanelVersions.h
+++ b/src/ESP_PanelVersions.h
@@ -11,7 +11,7 @@
 /* Library Version */
 #define ESP_PANEL_VERSION_MAJOR 0
 #define ESP_PANEL_VERSION_MINOR 1
-#define ESP_PANEL_VERSION_PATCH 5
+#define ESP_PANEL_VERSION_PATCH 6
 
 /* File `ESP_Panel_Conf.h` */
 #define ESP_PANEL_CONF_VERSION_MAJOR 0


### PR DESCRIPTION
Fix `LVGL_PORT_ROTATION_DEGREE` issue because of a missing `#` character.