### PR TITLE
[GT911] Fix EXAMPLE_TOUCH_ADDRESS missing as variable in I2C.ino

### DIFF
--- a/examples/Touch/I2C/I2C.ino
+++ b/examples/Touch/I2C/I2C.ino
@@ -101,7 +101,7 @@ void setup()
                             ESP_PANEL_TOUCH_I2C_PANEL_IO_CONFIG_WITH_ADDR(EXAMPLE_TOUCH_NAME, EXAMPLE_TOUCH_ADDRESS));
     // Taking GT911 as an example, the following is the code after macro expansion:
     // ESP_PanelBus_I2C *touch_bus = new ESP_PanelBus_I2C(EXAMPLE_TOUCH_PIN_NUM_I2C_SCL, EXAMPLE_TOUCH_PIN_NUM_I2C_SDA,
-    //                                                    ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG_WITH_ADDR());
+    //                                                    ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG_WITH_ADDR(EXAMPLE_TOUCH_ADDRESS));
 #endif
     touch_bus->configI2cFreqHz(EXAMPLE_TOUCH_I2C_FREQ_HZ);
     touch_bus->begin();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_Display_Panel
-version=0.1.5
+version=0.1.6
 author=espressif
 maintainer=espressif
 sentence=ESP32_Display_Panel is an Arduino library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.

--- a/src/ESP_PanelVersions.h
+++ b/src/ESP_PanelVersions.h
@@ -11,7 +11,7 @@
 /* Library Version */
 #define ESP_PANEL_VERSION_MAJOR 0
 #define ESP_PANEL_VERSION_MINOR 1
-#define ESP_PANEL_VERSION_PATCH 5
+#define ESP_PANEL_VERSION_PATCH 6
 
 /* File `ESP_Panel_Conf.h` */
 #define ESP_PANEL_CONF_VERSION_MAJOR 0


### PR DESCRIPTION
Fix `EXAMPLE_TOUCH_ADDRESS` missing as variable in I2C.ino.
Fixes #83.

## Steps to reproduce

1. Replace [ESP_Panel_Board_Custom.h](https://github.com/lboue/ESP32_Display_Panel/blob/ESP32-S3-Touch-LCD-4.3_TC_testing/examples/SquareLine/v8/WiFiClock/ESP_Panel_Board_Custom.h)

## Tests 
Tested with GT911

```
21:54:40.546 -> ============ After Setup End =============
21:54:47.265 -> Touch interrupt callback
21:54:47.265 -> Touch point(0): x 529, y 353, strength 56
21:54:47.302 -> Touch interrupt callback
21:54:47.302 -> Touch point(0): x 529, y 353, strength 56
21:54:47.302 -> Touch interrupt callback
21:54:47.302 -> Touch point(0): x 529, y 353, strength 56
21:54:47.302 -> Touch interrupt callback
```