### PR TITLE
Allow to set the GT911 touch device address

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_Display_Panel
-version=0.1.5
+version=0.1.6
 author=espressif
 maintainer=espressif
 sentence=ESP32_Display_Panel is an Arduino library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.

--- a/src/ESP_PanelVersions.h
+++ b/src/ESP_PanelVersions.h
@@ -11,7 +11,7 @@
 /* Library Version */
 #define ESP_PANEL_VERSION_MAJOR 0
 #define ESP_PANEL_VERSION_MINOR 1
-#define ESP_PANEL_VERSION_PATCH 5
+#define ESP_PANEL_VERSION_PATCH 6
 
 /* File `ESP_Panel_Conf.h` */
 #define ESP_PANEL_CONF_VERSION_MAJOR 0

--- a/src/touch/ESP_PanelTouch.cpp
+++ b/src/touch/ESP_PanelTouch.cpp
@@ -78,6 +78,25 @@ ESP_PanelTouch::ESP_PanelTouch(ESP_PanelBus *bus, const esp_lcd_touch_config_t &
     }
 }
 
+ESP_PanelTouch::ESP_PanelTouch(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config, int address):
+    bus(bus),
+    config(config),
+    handle(NULL),
+    _swap_xy(false),
+    _mirror_x(false),
+    _mirror_y(false),
+    _tp_points_num(0),
+    _tp_buttons_state{0},
+    onTouchInterruptCallback(NULL),
+    _isr_sem(NULL),
+    callback_data(CALLBACK_DATA_DEFAULT())
+{
+    if ((config.int_gpio_num != GPIO_NUM_NC) && (config.interrupt_callback == NULL) && (config.user_data == NULL)) {
+        this->config.interrupt_callback = onTouchInterrupt;
+        this->config.user_data = &callback_data;
+    }
+}
+
 bool ESP_PanelTouch::attachInterruptCallback(std::function<bool (void *)> callback, void *user_data)
 {
     ESP_PANEL_CHECK_FALSE_RET((config.interrupt_callback == onTouchInterrupt), false, "Interruption is not enabled");

--- a/src/touch/ESP_PanelTouch.h
+++ b/src/touch/ESP_PanelTouch.h
@@ -79,6 +79,15 @@ public:
     ESP_PanelTouch(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config);
 
     /**
+     * @brief Construct a new touch device in a complex way, the `init()` function should be called after this function
+     *
+     * @param bus    Pointer to panel bus
+     * @param config Touch device configuration
+     * @param address The address of the touch device, default set to `0` to use the default address    
+     */
+    ESP_PanelTouch(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config, int address);
+    
+    /**
      * @brief Destroy the LCD device
      *
      */

--- a/src/touch/ESP_PanelTouch.h
+++ b/src/touch/ESP_PanelTouch.h
@@ -86,7 +86,7 @@ public:
      * @param address The address of the touch device, default set to `0` to use the default address
      */
     ESP_PanelTouch(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config, int address);
-    
+
     /**
      * @brief Destroy the LCD device
      *

--- a/src/touch/ESP_PanelTouch.h
+++ b/src/touch/ESP_PanelTouch.h
@@ -83,7 +83,7 @@ public:
      *
      * @param bus    Pointer to panel bus
      * @param config Touch device configuration
-     * @param address The address of the touch device, default set to `0` to use the default address    
+     * @param address The address of the touch device, default set to `0` to use the default address
      */
     ESP_PanelTouch(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config, int address);
     

--- a/src/touch/GT911.cpp
+++ b/src/touch/GT911.cpp
@@ -19,6 +19,11 @@ ESP_PanelTouch_GT911::ESP_PanelTouch_GT911(ESP_PanelBus *bus, const esp_lcd_touc
 {
 }
 
+ESP_PanelTouch_GT911::ESP_PanelTouch_GT911(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config, int address):
+    ESP_PanelTouch(bus, config, address)
+{
+}
+
 ESP_PanelTouch_GT911::~ESP_PanelTouch_GT911()
 {
     ESP_PANEL_ENABLE_TAG_DEBUG_LOG();

--- a/src/touch/GT911.h
+++ b/src/touch/GT911.h
@@ -35,7 +35,7 @@ public:
      * @param config  Touch device configuration
      */
     ESP_PanelTouch_GT911(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config);
-    
+
     /**
      * @brief Construct a new touch device in a complex way, the `init()` function should be called after this function
      *

--- a/src/touch/GT911.h
+++ b/src/touch/GT911.h
@@ -33,9 +33,17 @@ public:
      *
      * @param bus     Pointer to panel bus
      * @param config  Touch device configuration
-     * @param address The address of the touch device, default set to `0` to use the default address
      */
     ESP_PanelTouch_GT911(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config);
+    
+    /**
+     * @brief Construct a new touch device in a complex way, the `init()` function should be called after this function
+     *
+     * @param bus     Pointer to panel bus
+     * @param config  Touch device configuration
+     * @param address The address of the touch device, default set to `0` to use the default address
+     */
+    ESP_PanelTouch_GT911(ESP_PanelBus *bus, const esp_lcd_touch_config_t &config, int address);
 
     /**
      * @brief Destroy the LCD device


### PR DESCRIPTION
Allow to set the GT911 touch device address (default set to `0` to use the default address)
Fixes #85.