### PR TITLE
LV_USE_DEMO_WIDGETS typo

### DIFF
--- a/examples/LVGL/v8/Porting/Porting.ino
+++ b/examples/LVGL/v8/Porting/Porting.ino
@@ -99,7 +99,7 @@ void setup()
 
     /**
      * Or try out a demo.
-     * Don't forget to uncomment header and enable the demos in `lv_conf.h`. E.g. `LV_USE_DEMOS_WIDGETS`
+     * Don't forget to uncomment header and enable the demos in `lv_conf.h`. E.g. `LV_USE_DEMO_WIDGETS`
      */
     // lv_demo_widgets();
     // lv_demo_benchmark();

--- a/examples/PlatformIO/src/app.cpp
+++ b/examples/PlatformIO/src/app.cpp
@@ -55,7 +55,7 @@ void setup()
 
     /**
      * Or try out a demo.
-     * Don't forget to uncomment header and enable the demos in `lv_conf.h`. E.g. `LV_USE_DEMOS_WIDGETS`
+     * Don't forget to uncomment header and enable the demos in `lv_conf.h`. E.g. `LV_USE_DEMO_WIDGETS`
      */
     // lv_demo_widgets();
     // lv_demo_benchmark();


### PR DESCRIPTION
### LV_USE_DEMO_WIDGETS typo

`LV_USE_DEMOS_WIDGETS` should be replaced by `LV_USE_DEMO_WIDGETS` according to LVGL doc: [demos/README.md](https://github.com/lvgl/lvgl/blob/4d96c27ce35dd2ea6b34926f24a647e7ea7c4b0c/demos/README.md?plain=1#L15) :

`
#define LV_USE_DEMO_WIDGETS        0
`