### PR TITLE
Implementation of Waveshare ESP32_S3_Touch_LCD_2.1 (RGB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v0.1.9 - 2024-10-29
+
+* feat(board): add support for Waveshare ESP32-S3-Touch-LCD-2.1
+
 ## v0.1.8 - 2024-10-25
 
 * feat(board): add support for Waveshare ESP32-S3-Touch-LCD-1.85

--- a/ESP_Panel_Board_Supported.h
+++ b/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Below is a list of [supported development boards](docs/Board_Instructions.md):
 | [Elecrow](docs/Board_Instructions.md#elecrow) | CrowPanel 7.0" |
 | [M5Stack](docs/Board_Instructions.md#m5stack) | M5STACK-M5CORE2, M5STACK-M5DIAL, M5STACK-M5CORES3 |
 | [Jingcai](docs/Board_Instructions.md#shenzhen-jingcai-intelligent) | ESP32-4848S040C_I_Y_3 |
-| [Waveshare](docs/Board_Instructions.md#waveshare) | ESP32-S3-Touch-LCD-4.3, ESP32-S3-Touch-LCD-1.85 |
+| [Waveshare](docs/Board_Instructions.md#waveshare) | ESP32-S3-Touch-LCD-4.3, ESP32-S3-Touch-LCD-1.85, ESP32-S3-Touch-LCD-2.1 |
 
 Developers and manufacturers are welcomed to contribute PRs to add more development boards. For detailed instructions, please refer to the [`Board Development Guide`](./docs/Board_Contribution_Guide.md).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,7 +66,7 @@ ESP32_Display_Panel 的功能框图如下所示，主要包含以下特性：
 | [M5Stack](docs/Board_Instructions.md#m5stack) | M5STACK-M5CORE2, M5STACK-M5DIAL, M5STACK-M5CORES3 |
 | [Elecrow](docs/Board_Instructions.md#elecrow) | CrowPanel 7.0" |
 | [Jingcai](docs/Board_Instructions.md#shenzhen-jingcai-intelligent) | ESP32-4848S040C_I_Y_3 |
-| [Waveshare](docs/Board_Instructions.md#waveshare) | ESP32-S3-Touch-LCD-4.3, ESP32-S3-Touch-LCD-1.85 |
+| [Waveshare](docs/Board_Instructions.md#waveshare) | ESP32-S3-Touch-LCD-4.3, ESP32-S3-Touch-LCD-1.85, ESP32-S3-Touch-LCD-2.1 |
 
 欢迎开发者和厂商贡献 PR 来添加更多的开发板，详细说明请参考 [`开发板贡献指南`](./docs/Board_Contribution_Guide_CN.md)。
 

--- a/docs/Board_Instructions.md
+++ b/docs/Board_Instructions.md
@@ -44,6 +44,7 @@
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------: | :--------------: | :----------------: | ------------------ | :-----------: | :------------------: |
 | <img src="https://www.waveshare.com/media/catalog/product/cache/1/small_image/171x171/9df78eab33525d08d6e5fb8d27136e95/e/s/esp32-s3-touch-lcd-4.3-1.jpg" width="150"> | [ESP32-S3-Touch-LCD-4.3](https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm) | RGB |       ST7262       |      800x480       |      I2C      |        GT911         |
 | <img src="https://www.waveshare.com/w/upload/5/5f/ESP32-S3-Touch-LCD-1.85_Entity.jpg" width="150"> | [ESP32-S3-Touch-LCD-1.85](https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm) | QSPI |       ST77916       |      360x360       |      I2C      |        CST816         |
+| <img src="https://www.waveshare.com/w/upload/thumb/1/10/ESP32-S3-Touch-LCD-2.1.jpg/300px-ESP32-S3-Touch-LCD-2.1.jpg" width="150"> | [ESP32-S3-Touch-LCD-1.85](https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm) | RGB |       ST7701       |      480x480       |      I2C      |        CST820 (CST816-like)         |
 
 ## Recommended Configurations in the Arduino IDE
 
@@ -68,6 +69,7 @@ Below are recommended configurations for developing GUI applications on differen
 |      ElecrowCrowPanel 7.0"       | ESP32S3 Dev Module |   OPI    | QIO 80MHz  |    4MB     |    Disabled     |     Huge App (3MB)      |
 | Waveshare-ESP32-S3-Touch-LCD-4.3 | ESP32S3 Dev Module |   OPI    | QIO 80MHz  |    8MB     |    Disabled     |     8M with spiffs      |
 | Waveshare-ESP32-S3-Touch-LCD-1.85 | ESP32S3 Dev Module |   OPI    | QIO 80MHz  |    16MB     |    Enabled     |     16M Flash (3MB)      |
+| Waveshare-ESP32-S3-Touch-LCD-2.1 | ESP32S3 Dev Module |   OPI    | QIO 80MHz  |    16MB     |    Enabled     |     16M Flash (3MB)      |
 
 **Notes:**
 

--- a/examples/LVGL/v8/Porting/ESP_Panel_Board_Supported.h
+++ b/examples/LVGL/v8/Porting/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/examples/LVGL/v8/Rotation/ESP_Panel_Board_Supported.h
+++ b/examples/LVGL/v8/Rotation/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/examples/Panel/PanelTest/ESP_Panel_Board_Supported.h
+++ b/examples/Panel/PanelTest/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/examples/PlatformIO/src/ESP_Panel_Board_Supported.h
+++ b/examples/PlatformIO/src/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/examples/SquareLine/v8/Porting/ESP_Panel_Board_Supported.h
+++ b/examples/SquareLine/v8/Porting/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/examples/SquareLine/v8/WiFiClock/ESP_Panel_Board_Supported.h
+++ b/examples/SquareLine/v8/WiFiClock/ESP_Panel_Board_Supported.h
@@ -79,10 +79,12 @@
  *
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3 (ESP32_S3_Touch_LCD_4_3): https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm
  *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85 (ESP32_S3_Touch_LCD_1_85): https://www.waveshare.com/esp32-s3-touch-lcd-1.85.htm
+ *  - BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1 (ESP32_S3_Touch_LCD_2_1): https://www.waveshare.com/esp32-s3-touch-lcd-2.1.htm
  *
  */
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3
 // #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
+// #define BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@
  *
  */
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_FILE_VERSION_PATCH 0
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ESP32_Display_Panel
-version=0.1.8
+version=0.1.9
 author=espressif
 maintainer=espressif
 sentence=ESP32_Display_Panel is an Arduino library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.
-paragraph=Currently supported boards:ESP32-C3-LCDkit,ESP32-S3-BOX,ESP32-S3-BOX-3,ESP32-S3-BOX-3B,ESP32-S3-BOX-3(beta),ESP32-S3-BOX-Lite,ESP32-S3-EYE,ESP32-S3-Korvo-2,ESP32-S3-LCD-EV-Board,ESP32-S3-LCD-EV-Board-2,ESP32-S3-USB-OTG,M5STACK-M5CORE2,M5STACK-M5DIAL,M5STACK-M5CORES3,ESP32-4848S040C_I_Y_3,ESP32-S3-Touch-LCD-4.3,ESP32-S3-Touch-LCD-1.85. Currently supported devices: Bus,LCD,Touch,Backlight,IO expander. Currently supported Bus: I2C,SPI,QSPI,3-wire SPI + RGB. Currently supported LCD controllers: EK9716B,GC9A01,GC9B71,GC9503,ILI9341,NV3022B,ST7262,ST7701,ST7789,ST7796,ST77916,ST77922. Currently supported Touch controllers: CST816S,FT5x06,GT1151,GT911,ST7123,TT21100,XPT2046.
+paragraph=Currently supported boards:ESP32-C3-LCDkit,ESP32-S3-BOX,ESP32-S3-BOX-3,ESP32-S3-BOX-3B,ESP32-S3-BOX-3(beta),ESP32-S3-BOX-Lite,ESP32-S3-EYE,ESP32-S3-Korvo-2,ESP32-S3-LCD-EV-Board,ESP32-S3-LCD-EV-Board-2,ESP32-S3-USB-OTG,M5STACK-M5CORE2,M5STACK-M5DIAL,M5STACK-M5CORES3,ESP32-4848S040C_I_Y_3,ESP32-S3-Touch-LCD-4.3,ESP32-S3-Touch-LCD-1.85,ESP32-S3-Touch-LCD-2.1. Currently supported devices: Bus,LCD,Touch,Backlight,IO expander. Currently supported Bus: I2C,SPI,QSPI,3-wire SPI + RGB. Currently supported LCD controllers: EK9716B,GC9A01,GC9B71,GC9503,ILI9341,NV3022B,ST7262,ST7701,ST7789,ST7796,ST77916,ST77922. Currently supported Touch controllers: CST816S,FT5x06,GT1151,GT911,ST7123,TT21100,XPT2046.
 category=Other
 architectures=esp32
 url=https://github.com/esp-arduino-libs/ESP32_Display_Panel

--- a/src/ESP_PanelVersions.h
+++ b/src/ESP_PanelVersions.h
@@ -11,7 +11,7 @@
 /* Library Version */
 #define ESP_PANEL_VERSION_MAJOR 0
 #define ESP_PANEL_VERSION_MINOR 1
-#define ESP_PANEL_VERSION_PATCH 8
+#define ESP_PANEL_VERSION_PATCH 9
 
 /* File `ESP_Panel_Conf.h` */
 #define ESP_PANEL_CONF_VERSION_MAJOR 0
@@ -25,7 +25,7 @@
 
 /* File `ESP_Panel_Board_Supported.h` */
 #define ESP_PANEL_BOARD_SUPPORTED_VERSION_MAJOR 0
-#define ESP_PANEL_BOARD_SUPPORTED_VERSION_MINOR 4
+#define ESP_PANEL_BOARD_SUPPORTED_VERSION_MINOR 5
 #define ESP_PANEL_BOARD_SUPPORTED_VERSION_PATCH 0
 
 /* Check if the current configuration file version is compatible with the library version */

--- a/src/board/ESP_PanelBoard.h
+++ b/src/board/ESP_PanelBoard.h
@@ -15,7 +15,8 @@
     defined(BOARD_ESP32_S3_LCD_EV_BOARD_V1_5) +  defined(BOARD_ESP32_S3_LCD_EV_BOARD_2) + \
     defined(BOARD_ESP32_S3_LCD_EV_BOARD_2_V1_5) + defined(BOARD_ESP32_S3_USB_OTG) +  defined(BOARD_ELECROW_CROWPANEL_7_0) + \
     defined(BOARD_M5STACK_M5CORE2) + defined(BOARD_M5STACK_M5DIAL) + defined(BOARD_M5STACK_M5CORES3) + \
-    defined(BOARD_ESP32_4848S040C_I_Y_3) + defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3) + defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85) \
+    defined(BOARD_ESP32_4848S040C_I_Y_3) + defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_4_3) + defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85) + \
+    defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1)    \
     > 1
     #error "Multiple boards enabled! Please check file `ESP_Panel_Board_Supported.h` and make sure only one board is enabled."
 #endif
@@ -64,6 +65,8 @@
     #include "board/waveshare/ESP32_S3_Touch_LCD_4_3.h"
 #elif defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85) || CONFIG_BOARD_WAVESHARE_ESP32_S3_Touch_LCD_1_85
     #include "board/waveshare/ESP32_S3_Touch_LCD_1_85.h"
+#elif defined(BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1) || CONFIG_BOARD_WAVESHARE_ESP32_S3_Touch_LCD_2_1
+    #include "board/waveshare/ESP32_S3_Touch_LCD_2_1.h"
 #else
     #error "Unknown board selected! Please check file `ESP_Panel_Board_Supported.h` and make sure only one board is enabled."
 #endif

--- a/src/board/waveshare/ESP32_S3_Touch_LCD_2_1.h
+++ b/src/board/waveshare/ESP32_S3_Touch_LCD_2_1.h
@@ -1,0 +1,340 @@
+/*
+ * SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+// *INDENT-OFF*
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Please update the following macros to configure the LCD panel /////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/* Set to 1 when using an LCD panel */
+#define ESP_PANEL_USE_LCD           (1)     // 0/1
+
+#if ESP_PANEL_USE_LCD
+/**
+ * LCD Controller Name
+ */
+#define ESP_PANEL_LCD_NAME          ST7701
+
+/* LCD resolution in pixels */
+#define ESP_PANEL_LCD_WIDTH         (480)
+#define ESP_PANEL_LCD_HEIGHT        (480)
+
+/* LCD Bus Settings */
+/**
+ * If set to 1, the bus will skip to initialize the corresponding host. Users need to initialize the host in advance.
+ * It is useful if other devices use the same host. Please ensure that the host is initialized only once.
+ */
+#define ESP_PANEL_LCD_BUS_SKIP_INIT_HOST    (0)     // 0/1
+/**
+ * LCD Bus Type.
+ */
+#define ESP_PANEL_LCD_BUS_TYPE      (ESP_PANEL_BUS_TYPE_RGB)
+/**
+ * LCD Bus Parameters.
+ *
+ * Please refer to https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/lcd.html and
+ * https://docs.espressif.com/projects/esp-iot-solution/en/latest/display/lcd/index.html for more details.
+ *
+ */
+#if ESP_PANEL_LCD_BUS_TYPE == ESP_PANEL_BUS_TYPE_RGB
+
+    #define ESP_PANEL_LCD_RGB_CLK_HZ            (16 * 1000 * 1000)
+    #define ESP_PANEL_LCD_RGB_HPW               (8)
+    #define ESP_PANEL_LCD_RGB_HBP               (10)
+    #define ESP_PANEL_LCD_RGB_HFP               (50)
+    #define ESP_PANEL_LCD_RGB_VPW               (3)
+    #define ESP_PANEL_LCD_RGB_VBP               (8)
+    #define ESP_PANEL_LCD_RGB_VFP               (8)
+    #define ESP_PANEL_LCD_RGB_PCLK_ACTIVE_NEG   (0)     // 0: rising edge, 1: falling edge
+
+                                                        // | 8-bit RGB888 | 16-bit RGB565 |
+                                                        // |--------------|---------------|
+    #define ESP_PANEL_LCD_RGB_DATA_WIDTH        (16)    // |      8       |      16       |
+    #define ESP_PANEL_LCD_RGB_PIXEL_BITS        (16)    // |      24      |      16       |
+
+    #define ESP_PANEL_LCD_RGB_FRAME_BUF_NUM     (2)     // 1/2/3
+    #define ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE   (ESP_PANEL_LCD_WIDTH*10)     // Bounce buffer size in bytes. This function is used to avoid screen drift.
+                                                        // To enable the bounce buffer, set it to a non-zero value. Typically set to `ESP_PANEL_LCD_WIDTH * 10`
+                                                        // The size of the Bounce Buffer must satisfy `width_of_lcd * height_of_lcd = size_of_buffer * N`,
+                                                        // where N is an even number.
+    #define ESP_PANEL_LCD_RGB_IO_HSYNC          (38)
+    #define ESP_PANEL_LCD_RGB_IO_VSYNC          (39)
+    #define ESP_PANEL_LCD_RGB_IO_DE             (40)    // -1 if not used
+    #define ESP_PANEL_LCD_RGB_IO_PCLK           (41)
+    #define ESP_PANEL_LCD_RGB_IO_DISP           (-1)    // -1 if not used
+
+                                                        // | RGB565 | RGB666 | RGB888 |
+                                                        // |--------|--------|--------|
+    #define ESP_PANEL_LCD_RGB_IO_DATA0          (5)     // |   B0   |  B0-1  |   B0-3 |
+    #define ESP_PANEL_LCD_RGB_IO_DATA1          (45)    // |   B1   |  B2    |   B4   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA2          (48)    // |   B2   |  B3    |   B5   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA3          (47)    // |   B3   |  B4    |   B6   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA4          (21)    // |   B4   |  B5    |   B7   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA5          (14)    // |   G0   |  G0    |   G0-2 |
+    #define ESP_PANEL_LCD_RGB_IO_DATA6          (13)    // |   G1   |  G1    |   G3   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA7          (12)    // |   G2   |  G2    |   G4   |
+#if ESP_PANEL_LCD_RGB_DATA_WIDTH > 8
+    #define ESP_PANEL_LCD_RGB_IO_DATA8          (11)    // |   G3   |  G3    |   G5   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA9          (10)    // |   G4   |  G4    |   G6   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA10         (9)     // |   G5   |  G5    |   G7   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA11         (46)    // |   R0   |  R0-1  |   R0-3 |
+    #define ESP_PANEL_LCD_RGB_IO_DATA12         (3)     // |   R1   |  R2    |   R4   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA13         (8)     // |   R2   |  R3    |   R5   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA14         (18)    // |   R3   |  R4    |   R6   |
+    #define ESP_PANEL_LCD_RGB_IO_DATA15         (17)    // |   R4   |  R5    |   R7   |
+#endif
+
+#if !ESP_PANEL_LCD_BUS_SKIP_INIT_HOST
+    #define ESP_PANEL_LCD_3WIRE_SPI_IO_CS               (2)
+    #define ESP_PANEL_LCD_3WIRE_SPI_IO_SCK              (2)
+    #define ESP_PANEL_LCD_3WIRE_SPI_IO_SDA              (1)
+    #define ESP_PANEL_LCD_3WIRE_SPI_CS_USE_EXPNADER     (1)     // 0/1
+    #define ESP_PANEL_LCD_3WIRE_SPI_SCL_USE_EXPNADER    (0)     // 0/1
+    #define ESP_PANEL_LCD_3WIRE_SPI_SDA_USE_EXPNADER    (0)     // 0/1
+    #define ESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE     (0)     // 0: rising edge, 1: falling edge
+    #define ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO       (0)     // Delete the panel IO instance automatically if set to 1.
+                                                                // If the 3-wire SPI pins are sharing other pins of the RGB interface to save GPIOs,
+                                                                // Please set it to 1 to release the panel IO and its pins (except CS signal).
+    #define ESP_PANEL_LCD_FLAGS_MIRROR_BY_CMD           (!ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO)
+                                                                // The `mirror()` function will be implemented by LCD command if set to 1.
+#endif
+
+#else
+
+#error "The function is not ready and will be implemented in the future."
+
+#endif /* ESP_PANEL_LCD_BUS_TYPE */
+
+/**
+ * LCD Vendor Initialization Commands.
+ *
+ * Vendor specific initialization can be different between manufacturers, should consult the LCD supplier for
+ * initialization sequence code. Please uncomment and change the following macro definitions. Otherwise, the LCD driver
+ * will use the default initialization sequence code.
+ *
+ * There are two formats for the sequence code:
+ *   1. Raw data: {command, (uint8_t []){ data0, data1, ... }, data_size, delay_ms}
+ *   2. Formater: ESP_PANEL_LCD_CMD_WITH_8BIT_PARAM(delay_ms, command, { data0, data1, ... }) and
+ *                ESP_PANEL_LCD_CMD_WITH_NONE_PARAM(delay_ms, command)
+ */
+#define ESP_PANEL_LCD_VENDOR_INIT_CMD()                                                                                                 \
+    {                                                                                                                                   \
+        {0xFF, (uint8_t []){0x77, 0x01, 0x00, 0x00, 0x10}, 5, 0},                                                                       \
+        {0xC0, (uint8_t []){0x3B, 0x00}, 2, 0},                                                                                         \
+        {0xC1, (uint8_t []){0x0B, 0x02}, 2, 0},                                                                                         \
+        {0xC2, (uint8_t []){0x07, 0x02}, 2, 0},                                                                                         \
+        {0xCC, (uint8_t []){0x10}, 1, 0},                                                                                               \
+        {0xCD, (uint8_t []){0x08}, 1, 0},                                                                                               \
+        {0xB0, (uint8_t []){0x00, 0x11, 0x16, 0x0E, 0x11, 0x06, 0x05, 0x09, 0x08, 0x21, 0x06, 0x13, 0x10, 0x29, 0x31, 0x18}, 16, 0},    \
+        {0xB1, (uint8_t []){0x00, 0x11, 0x16, 0x0E, 0x11, 0x07, 0x05, 0x09, 0x09, 0x21, 0x05, 0x13, 0x11, 0x2A, 0x31, 0x18}, 16, 0},    \
+        {0xFF, (uint8_t []){0x77, 0x01, 0x00, 0x00, 0x11}, 5, 0},                                                                       \
+        {0xB0, (uint8_t []){0x6D}, 1, 0},                                                                                               \
+        {0xB1, (uint8_t []){0x37}, 1, 0},                                                                                               \
+        {0xB2, (uint8_t []){0x81}, 1, 0},                                                                                               \
+        {0xB3, (uint8_t []){0x80}, 1, 0},                                                                                               \
+        {0xB5, (uint8_t []){0x43}, 1, 0},                                                                                               \
+        {0xB7, (uint8_t []){0x85}, 1, 0},                                                                                               \
+        {0xB8, (uint8_t []){0x20}, 1, 0},                                                                                               \
+        {0xC1, (uint8_t []){0x78}, 1, 0},                                                                                               \
+        {0xC2, (uint8_t []){0x78}, 1, 0},                                                                                               \
+        {0xD0, (uint8_t []){0x88}, 1, 0},                                                                                               \
+        {0xE0, (uint8_t []){0x00, 0x00, 0x02}, 3, 0},                                                                                   \
+        {0xE1, (uint8_t []){0x03, 0xA0, 0x00, 0x00, 0x04, 0xA0, 0x00, 0x00, 0x00, 0x20, 0x20}, 11, 0},                                  \
+        {0xE2, (uint8_t []){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 13, 0},                      \
+        {0xE3, (uint8_t []){0x00, 0x00, 0x11, 0x00}, 4, 0},                                                                             \
+        {0xE4, (uint8_t []){0x22, 0x00}, 2, 0},                                                                                         \
+        {0xE5, (uint8_t []){0x05, 0xEC, 0xA0, 0xA0, 0x07, 0xEE, 0xA0, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 16, 0},    \
+        {0xE6, (uint8_t []){0x00, 0x00, 0x11, 0x00}, 4, 0},                                                                             \
+        {0xE7, (uint8_t []){0x22, 0x00}, 2, 0},                                                                                         \
+        {0xE8, (uint8_t []){0x06, 0xED, 0xA0, 0xA0, 0x08, 0xEF, 0xA0, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 16, 0},    \
+        {0xEB, (uint8_t []){0x00, 0x00, 0x40, 0x40, 0x00, 0x00, 0x00}, 7, 0},                                                           \
+        {0xED, (uint8_t []){0xFF, 0xFF, 0xFF, 0xBA, 0x0A, 0xBF, 0x45, 0xFF, 0xFF, 0x54, 0xFB, 0xA0, 0xAB, 0xFF, 0xFF, 0xFF}, 16, 0},    \
+        {0xEF, (uint8_t []){0x10, 0x0D, 0x04, 0x08, 0x3F, 0x1F}, 6, 0},                                                                 \
+        {0xFF, (uint8_t []){0x77, 0x01, 0x00, 0x00, 0x13}, 5, 0},                                                                       \
+        {0xEF, (uint8_t []){0x08}, 1, 0},                                                                                               \
+        {0xFF, (uint8_t []){0x77, 0x01, 0x00, 0x00, 0x00}, 5, 0},                                                                       \
+        {0x36, (uint8_t []){0x00}, 1, 0},                                                                                               \
+        {0x3A, (uint8_t []){0x66}, 1, 0},                                                                                               \
+        ESP_PANEL_LCD_CMD_WITH_NONE_PARAM(480, 0x11),                                                                                   \
+        ESP_PANEL_LCD_CMD_WITH_NONE_PARAM(120, 0x20),                                                                                   \
+        ESP_PANEL_LCD_CMD_WITH_NONE_PARAM(0, 0x29)                                                                                      \
+    }
+
+/* LCD Color Settings */
+/* LCD color depth in bits */
+#define ESP_PANEL_LCD_COLOR_BITS    (16)        // 8/16/18/24
+/*
+ * LCD RGB Element Order. Choose one of the following:
+ *      - 0: RGB
+ *      - 1: BGR
+ */
+#define ESP_PANEL_LCD_BGR_ORDER     (0)         // 0/1
+#define ESP_PANEL_LCD_INEVRT_COLOR  (0)         // 0/1
+
+/* LCD Transformation Flags */
+#define ESP_PANEL_LCD_SWAP_XY       (0)         // 0/1
+#define ESP_PANEL_LCD_MIRROR_X      (0)         // 0/1
+#define ESP_PANEL_LCD_MIRROR_Y      (0)         // 0/1
+
+/* LCD Other Settings */
+/* Reset pin */
+#define ESP_PANEL_LCD_IO_RST          (-1)      // IO num of RESET pin, set to -1 if not use
+#define ESP_PANEL_LCD_RST_LEVEL       (0)       // Active level. 0: low level, 1: high level
+
+#endif /* ESP_PANEL_USE_LCD */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Please update the following macros to configure the touch panel ///////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/* Set to 1 when using an touch panel */
+#define ESP_PANEL_USE_TOUCH         (1)         // 0/1
+#if ESP_PANEL_USE_TOUCH
+/**
+ * Touch controller name.
+ */
+#define ESP_PANEL_TOUCH_NAME        CST816S     //Actually a CST820 but the data structure is similar
+
+/* Touch resolution in pixels */
+#define ESP_PANEL_TOUCH_H_RES       (ESP_PANEL_LCD_WIDTH)   // Typically set to the same value as the width of LCD
+#define ESP_PANEL_TOUCH_V_RES       (ESP_PANEL_LCD_HEIGHT)  // Typically set to the same value as the height of LCD
+
+/* Touch Panel Bus Settings */
+/**
+ * If set to 1, the bus will skip to initialize the corresponding host. Users need to initialize the host in advance.
+ * It is useful if other devices use the same host. Please ensure that the host is initialized only once.
+ */
+#define ESP_PANEL_TOUCH_BUS_SKIP_INIT_HOST      (0)     // 0/1
+/**
+ * Touch panel bus type.
+ */
+#define ESP_PANEL_TOUCH_BUS_TYPE            (ESP_PANEL_BUS_TYPE_I2C)
+/* Touch panel bus parameters */
+#if ESP_PANEL_TOUCH_BUS_TYPE == ESP_PANEL_BUS_TYPE_I2C
+
+    #define ESP_PANEL_TOUCH_BUS_HOST_ID     (0)     // Typically set to 0
+    #define ESP_PANEL_TOUCH_I2C_ADDRESS     (0)     // Typically set to 0 to use the default address.
+                                                    // - For touchs with only one address, set to 0
+                                                    // - For touchs with multiple addresses, set to 0 or the address
+                                                    //   Like GT911, there are two addresses: 0x5D(default) and 0x14
+#if !ESP_PANEL_TOUCH_BUS_SKIP_INIT_HOST
+    #define ESP_PANEL_TOUCH_I2C_CLK_HZ      (400 * 1000)
+                                                    // Typically set to 400K
+    #define ESP_PANEL_TOUCH_I2C_SCL_PULLUP  (1)     // 0/1
+    #define ESP_PANEL_TOUCH_I2C_SDA_PULLUP  (1)     // 0/1
+    #define ESP_PANEL_TOUCH_I2C_IO_SCL      (7)
+    #define ESP_PANEL_TOUCH_I2C_IO_SDA      (15)
+#endif
+
+#endif /* ESP_PANEL_TOUCH_BUS_TYPE */
+
+/* Touch Transformation Flags */
+#define ESP_PANEL_TOUCH_SWAP_XY         (0)         // 0/1
+#define ESP_PANEL_TOUCH_MIRROR_X        (0)         // 0/1
+#define ESP_PANEL_TOUCH_MIRROR_Y        (0)         // 0/1
+
+/* Touch Other Settings */
+/* Reset pin */
+#define ESP_PANEL_TOUCH_IO_RST          (-1)        // IO num of RESET pin, set to -1 if not use
+                                                    // For GT911, the RST pin is also used to configure the I2C address
+#define ESP_PANEL_TOUCH_RST_LEVEL       (0)         // Active level. 0: low level, 1: high level
+/* Interrupt pin */
+#define ESP_PANEL_TOUCH_IO_INT          (16)        // IO num of INT pin, set to -1 if not use
+                                                    // For GT911, the INT pin is also used to configure the I2C address
+#define ESP_PANEL_TOUCH_INT_LEVEL       (1)         // Active level. 0: low level, 1: high level
+
+#endif /* ESP_PANEL_USE_TOUCH */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////// Please update the following macros to configure the backlight ////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_USE_BACKLIGHT         (1)         // 0/1
+#if ESP_PANEL_USE_BACKLIGHT
+/* Backlight pin */
+#define ESP_PANEL_BACKLIGHT_IO          (6)        // IO num of backlight pin
+#define ESP_PANEL_BACKLIGHT_ON_LEVEL    (1)         // 0: low level, 1: high level
+
+/* Set to 1 if you want to turn off the backlight after initializing the panel; otherwise, set it to turn on */
+#define ESP_PANEL_BACKLIGHT_IDLE_OFF    (0)         // 0: on, 1: off
+
+/* Set to 1 if use PWM for brightness control */
+#define ESP_PANEL_LCD_BL_USE_PWM        (1)         // 0/1
+#endif /* ESP_PANEL_USE_BACKLIGHT */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////// Please update the following macros to configure the IO expander //////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/* Set to 0 if not using IO Expander */
+#define ESP_PANEL_USE_EXPANDER          (1)         // 0/1
+#if ESP_PANEL_USE_EXPANDER
+/**
+ * IO expander name.
+ */
+#define ESP_PANEL_EXPANDER_NAME         TCA95xx_8bit
+
+/* IO expander Settings */
+/**
+ * If set to 1, the driver will skip to initialize the corresponding host. Users need to initialize the host in advance.
+ * It is useful if other devices use the same host. Please ensure that the host is initialized only once.
+ */
+#define ESP_PANEL_EXPANDER_SKIP_INIT_HOST       (1)     // 0/1
+/* IO expander parameters */
+#define ESP_PANEL_EXPANDER_HOST_ID              (0)     // Typically set to 0
+#define ESP_PANEL_EXPANDER_I2C_ADDRESS          (0x20)  // The actual I2C address. Even for the same model of IC,
+                                                        // the I2C address may be different, and confirmation based on
+                                                        // the actual hardware connection is required
+#if !ESP_PANEL_EXPANDER_SKIP_INIT_HOST
+    #define ESP_PANEL_EXPANDER_I2C_CLK_HZ       (400 * 1000)
+                                                        // Typically set to 400K
+    #define ESP_PANEL_EXPANDER_I2C_SCL_PULLUP   (1)     // 0/1
+    #define ESP_PANEL_EXPANDER_I2C_SDA_PULLUP   (1)     // 0/1
+    #define ESP_PANEL_EXPANDER_I2C_IO_SCL       (7)
+    #define ESP_PANEL_EXPANDER_I2C_IO_SDA       (15)
+#endif
+#endif /* ESP_PANEL_USE_EXPANDER */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////// Please utilize the following macros to execute any additional code if required. //////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// #define ESP_PANEL_BEGIN_START_FUNCTION( panel )
+// #define ESP_PANEL_BEGIN_EXPANDER_START_FUNCTION( panel )
+//  #define ESP_PANEL_BEGIN_EXPANDER_END_FUNCTION( panel )
+// #define ESP_PANEL_BEGIN_LCD_START_FUNCTION( panel )
+// #define ESP_PANEL_BEGIN_LCD_END_FUNCTION( panel )
+#define ESP_PANEL_BEGIN_TOUCH_START_FUNCTION( panel )   \
+{  \
+    _expander_ptr->pinMode(1,OUTPUT); \
+    _expander_ptr->digitalWrite(1,LOW); \
+    vTaskDelay(pdMS_TO_TICKS(30));  \
+    _expander_ptr->digitalWrite(1,HIGH); \
+    vTaskDelay(pdMS_TO_TICKS(50)); \
+}
+// #define ESP_PANEL_BEGIN_TOUCH_END_FUNCTION( panel )
+// #define ESP_PANEL_BEGIN_BACKLIGHT_START_FUNCTION( panel )
+// #define ESP_PANEL_BEGIN_BACKLIGHT_END_FUNCTION( panel )
+// #define ESP_PANEL_BEGIN_END_FUNCTION( panel )
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Do not change the following versions, they are used to check if the configurations in this file are compatible with
+ * the current version of `ESP_Panel_Board_Custom.h` in the library. The detailed rules are as follows:
+ *
+ *   1. If the major version is not consistent, then the configurations in this file are incompatible with the library
+ *      and must be replaced with the file from the library.
+ *   2. If the minor version is not consistent, this file might be missing some new configurations, which will be set to
+ *      default values. It is recommended to replace it with the file from the library.
+ *   3. Even if the patch version is not consistent, it will not affect normal functionality.
+ *
+ */
+#define ESP_PANEL_BOARD_CUSTOM_FILE_VERSION_MAJOR 0
+#define ESP_PANEL_BOARD_CUSTOM_FILE_VERSION_MINOR 2
+#define ESP_PANEL_BOARD_CUSTOM_FILE_VERSION_PATCH 2
+
+
+// *INDENT-OFF*


### PR DESCRIPTION
Surprise ! I was experimenting with another round LCD from Waveshare, this time with RGB instead of QSPI. I managed to get it to work seemingly all good, so here is an update of the supported panel boards. 
Normally I did it all by the book in one go there.
To note : this panel uses a CST820 for touch, but the communication parameters are the same as for CST816S if limiting it to a single point detection. It works the same in my testing.