### PR TITLE
fix(lcd): use 'delete[]' instead of 'delete' for C array shared pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugfixes:
 
 * fix(lcd): use 'delete[]' instead of 'delete' for C array shared pointer @FranciscoMoya (#142)
-* fix(Kconfig): fix incorrect descriptions
+* fix(Kconfig): fix build error on esp-idf and incorrect descriptions @Cathgao (#133)
 
 ## v0.2.1 - 2024-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## v0.2.2 - 2024-12-23
+
+### Bugfixes:
+
+* fix(lcd): use 'delete[]' instead of 'delete' for C array shared pointer @FranciscoMoya (#142)
+* fix(Kconfig): fix incorrect descriptions
+
 ## v0.2.1 - 2024-11-14
 
 ### Enhancements:

--- a/Kconfig
+++ b/Kconfig
@@ -1,10 +1,10 @@
 menu "ESP Display Panel Configurations"
     config ESP_PANEL_CONF_FILE_SKIP
-        bool "Unckeck this to ignore `ESP_Panel_Conf.h`"
+        bool "Unckeck this to use `ESP_Panel_Conf.h`"
         default y
 
     config ESP_PANEL_BOARD_FILE_SKIP
-        bool "Unckeck this to ignore `ESP_Panel_Board_*.h`"
+        bool "Unckeck this to use `ESP_Panel_Board_*.h`"
         default y
 
     config ESP_PANEL_CHECK_RESULT_ASSERT

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.1"
+version: "0.2.2"
 description: ESP32_Display_Panel is a library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.
 url: https://github.com/esp-arduino-libs/ESP32_Display_Panel
 repository: https://github.com/esp-arduino-libs/ESP32_Display_Panel.git

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_Display_Panel
-version=0.2.1
+version=0.2.2
 author=espressif
 maintainer=espressif
 sentence=ESP32_Display_Panel is a library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.

--- a/src/ESP_PanelVersions.h
+++ b/src/ESP_PanelVersions.h
@@ -11,7 +11,7 @@
 /* Library Version */
 #define ESP_PANEL_VERSION_MAJOR 0
 #define ESP_PANEL_VERSION_MINOR 2
-#define ESP_PANEL_VERSION_PATCH 1
+#define ESP_PANEL_VERSION_PATCH 2
 
 /* File `ESP_Panel_Conf.h` */
 #define ESP_PANEL_CONF_VERSION_MAJOR 0

--- a/src/ESP_Panel_Board_Kconfig.h
+++ b/src/ESP_Panel_Board_Kconfig.h
@@ -480,6 +480,13 @@
                         #define ESP_PANEL_LCD_3WIRE_SPI_SDA_USE_EXPNADER 0
                     #endif
                 #endif
+                #ifndef ESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE
+                    #ifdef CONfIGESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE
+                        #define ESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE CONFIG_ESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE
+                    #else
+                        #define ESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE 0
+                    #endif
+                #endif
                 #ifndef ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO
                     #ifdef CONFIG_ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO
                         #define ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO CONFIG_ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO
@@ -585,6 +592,13 @@
                     #define ESP_PANEL_LCD_RGB_PIXEL_BITS CONFIG_ESP_PANEL_LCD_RGB_PIXEL_BITS
                 #else
                     #error "Missing configuration: ESP_PANEL_LCD_RGB_PIXEL_BITS"
+                #endif
+            #endif
+            #ifndef ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE
+                #ifdef CONFIG_ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE
+                    #define ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE CONFIG_ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE
+                #else
+                    #define ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE 0
                 #endif
             #endif
             #ifndef ESP_PANEL_LCD_RGB_IO_HSYNC
@@ -1040,6 +1054,13 @@
                 #define ESP_PANEL_BACKLIGHT_IDLE_OFF CONFIG_ESP_PANEL_BACKLIGHT_IDLE_OFF
             #else
                 #define ESP_PANEL_BACKLIGHT_IDLE_OFF 0
+            #endif
+        #endif
+        #ifndef ESP_PANEL_LCD_BL_USE_PWM
+            #ifdef CONFIG_ESP_PANEL_LCD_BL_USE_PWM
+                #define ESP_PANEL_LCD_BL_USE_PWM CONFIG_ESP_PANEL_LCD_BL_USE_PWM
+            #else
+                #define ESP_PANEL_LCD_BL_USE_PWM 0
             #endif
         #endif
     #endif /* ESP_PANEL_USE_BACKLIGHT */

--- a/src/board/Kconfig.board_custom
+++ b/src/board/Kconfig.board_custom
@@ -242,6 +242,12 @@ menu "LCD settings"
                     bool "Use IO expander to control SDA"
                     default n
 
+                config ESP_PANEL_LCD_3WIRE_SPI_SCL_ACTIVE_EDGE
+                    bool "SCL active falling edge"
+                    default n
+                    help
+                        If set to 1, the SCL signal will be active on the falling edge; otherwise, it will be active on the raising edge.
+
                 config ESP_PANEL_LCD_FLAGS_AUTO_DEL_PANEL_IO
                     bool "Auto delete panel IO instance"
                     default n
@@ -333,6 +339,11 @@ menu "LCD settings"
                     int
                     default 24 if ESP_PANEL_LCD_RGB_DATA_WIDTH_8
                     default 16 if ESP_PANEL_LCD_RGB_DATA_WIDTH_16
+
+                config ESP_PANEL_LCD_RGB_BOUNCE_BUF_SIZE
+                    int "Bounce buffer size (bytes)"
+                    default 0
+                    range 0 10000000
 
                 menu "Pins"
                     config ESP_PANEL_LCD_RGB_IO_HSYNC

--- a/src/lcd/ESP_PanelLcd.cpp
+++ b/src/lcd/ESP_PanelLcd.cpp
@@ -484,7 +484,7 @@ bool ESP_PanelLcd::colorBarTest(uint16_t width, uint16_t height)
     int res_line_count = 0;
 
     /* Malloc memory for a single color bar */
-    shared_ptr<uint8_t> single_bar_buf(new uint8_t[row_per_bar * width * bytes_per_piexl]);
+    shared_ptr<uint8_t> single_bar_buf(new uint8_t[row_per_bar * width * bytes_per_piexl], [](uint8_t* ptr) { delete[] ptr; });
     ESP_PANEL_CHECK_FALSE_RET(single_bar_buf != nullptr, false, "Malloc color buffer failed");
 
     /* Draw color bar from top left to bottom right, the order is B - G - R */


### PR DESCRIPTION
* fix(lcd): use 'delete[]' instead of 'delete' for C array shared pointer @FranciscoMoya (#142)
* fix(Kconfig): fix build error on esp-idf and incorrect descriptions @Cathgao (#133)