### PR TITLE
fix(log): fix kernel panic when checking the error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfixes:
 
 * fix(touch): fix GT911 build warning
+* fix(log): fix kernel panic when checking the error @Kanzll (#144)
 * fix(version): fix minor number check @arduinomnomnom (#148)
 
 ## v0.2.2 - 2025-01-09

--- a/examples/PlatformIO/platformio.ini
+++ b/examples/PlatformIO/platformio.ini
@@ -10,7 +10,7 @@ monitor_speed = 115200
 build_flags =
 ; Arduino related:
         -DBOARD_HAS_PSRAM               ; Enable PSRAM
-; -DARDUINO_USB_CDC_ON_BOOT=0     ; If using UART port
+        ; -DARDUINO_USB_CDC_ON_BOOT=0     ; If using UART port
         -DARDUINO_USB_CDC_ON_BOOT=1     ; If using USB port
         -DCORE_DEBUG_LEVEL=1            ; Set to `5` for full debug output, `0` for none
 ; LVGL related:

--- a/src/ESP_PanelLog.h
+++ b/src/ESP_PanelLog.h
@@ -30,15 +30,11 @@
 #define ESP_PANEL_CHECK_NULL_RET(x, ...)    assert((x) != NULL)
 #define ESP_PANEL_CHECK_FALSE_RET(x, ...)   assert((x) != false)
 #else
-// #if ESP_PANEL_ENABLE_LOG
-#define ESP_PANEL_ERROR_CHECK_LOG_FORMAT(err, format)     "[%s] %s(%u): " format, esp_err_to_name(err), __FUNCTION__, __LINE__
-#define ESP_PANEL_ERROR_CHECK_LOGE(tag, err, format, ...) ESP_LOGE(tag, ESP_PANEL_ERROR_CHECK_LOG_FORMAT(err, format), ##__VA_ARGS__)
-#define ESP_PANEL_OTHER_CHECK_LOG_FORMAT(format)      "%s(%u): " format, __FUNCTION__, __LINE__
-#define ESP_PANEL_OTHER_CHECK_LOGE(tag, format, ...)  ESP_LOGE(tag, ESP_PANEL_OTHER_CHECK_LOG_FORMAT(format), ##__VA_ARGS__)
-// #else
-// #define ESP_PANEL_ERROR_CHECK_LOGE(tag, err, format, ...) do {} while(0)
-// #define ESP_PANEL_OTHER_CHECK_LOGE(tag, format, ...) do {} while(0)
-// #endif
+
+#define ESP_PANEL_ERROR_CHECK_LOGE(tag, err, format, ...) \
+    ESP_LOGE(tag, "[%s] %s(%u): " format, esp_err_to_name(err), __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define ESP_PANEL_OTHER_CHECK_LOGE(tag, format, ...) \
+    ESP_LOGE(tag, "%s(%u): " format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
 #define ESP_PANEL_CHECK_ERR_RET(x, ret, fmt, ...) do {                    \
         esp_err_t err_rc_ = (x);                                          \


### PR DESCRIPTION
### Bugfixes:

* fix(log): fix kernel panic when checking the error @Kanzll (#144)