### PR TITLE
Update lv_conf.h for Arduino IDE

### DIFF
--- a/examples/arduino/gui/lvgl_v8/squareline_wifi_clock/lv_conf.h
+++ b/examples/arduino/gui/lvgl_v8/squareline_wifi_clock/lv_conf.h
@@ -360,7 +360,7 @@
  *===================*/
 
 /*Montserrat fonts with ASCII range and some symbols using bpp = 4
- *https://fonts.google.com/specimen/Montserrat*/
+ *https://fonts.google.com/specimen/Montserrat */
 #define LV_FONT_MONTSERRAT_8  1
 #define LV_FONT_MONTSERRAT_10 1
 #define LV_FONT_MONTSERRAT_12 1
@@ -469,7 +469,7 @@
  *  WIDGET USAGE
  *================*/
 
-/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
+/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html */
 
 #define LV_USE_ARC        1
 


### PR DESCRIPTION
Arduino IDE 1.8.19 uses the end comment signifier */ at the of URLS as part of the URL, commenting