### PR TITLE
Fix ST7701 conditional compilation logic for MIPI-DSI support

### DIFF
--- a/src/drivers/lcd/esp_panel_lcd_st7701.cpp
+++ b/src/drivers/lcd/esp_panel_lcd_st7701.cpp
@@ -61,7 +61,7 @@ bool LCD_ST7701::init()
     // Process the device on initialization
     ESP_UTILS_CHECK_FALSE_RETURN(processDeviceOnInit(_bus_specifications), false, "Process device on init failed");
 
-#if ESP_PANEL_DRIVERS_BUS_ENABLE_RGB
+#if ESP_PANEL_DRIVERS_BUS_ENABLE_RGB || ESP_PANEL_DRIVERS_BUS_ENABLE_MIPI_DSI
     // Create refresh panel
     ESP_UTILS_CHECK_ERROR_RETURN(
         esp_lcd_new_panel_st7701(
@@ -70,8 +70,8 @@ bool LCD_ST7701::init()
     );
     ESP_UTILS_LOGD("Create refresh panel(@%p)", refresh_panel);
 #else
-    ESP_UTILS_CHECK_FALSE_RETURN(false, false, "MIPI-DSI is not supported");
-#endif // ESP_PANEL_DRIVERS_BUS_ENABLE_RGB
+    ESP_UTILS_CHECK_FALSE_RETURN(false, false, "Neither RGB nor MIPI-DSI is supported");
+#endif // ESP_PANEL_DRIVERS_BUS_ENABLE_RGB || ESP_PANEL_DRIVERS_BUS_ENABLE_MIPI_DSI
 
     /* Disable control panel if enable `auto_del_panel_io/enable_io_multiplex` flag */
     if (getConfig().getVendorFullConfig()->flags.auto_del_panel_io) {


### PR DESCRIPTION
## 🛠️ Summary

Fix conditional compilation logic in the **ST7701 LCD driver** that incorrectly rejected **MIPI-DSI** interface configurations.

## Changes

* Adjusted conditional check to include `ESP_PANEL_DRIVERS_BUS_ENABLE_MIPI_DSI` along with RGB support.
* Updated error message to accurately reflect support for **both RGB and MIPI-DSI** interfaces.
* Corrected `#endif` comment to match the revised conditional logic.

## Problem

The `init()` method of the **ST7701 driver** previously **only checked for `ESP_PANEL_DRIVERS_BUS_ENABLE_RGB`**, which resulted in **MIPI-DSI configurations being incorrectly rejected** with the misleading error:

```
MIPI-DSI is not supported
```

Despite this, the underlying function `esp_lcd_new_panel_st7701()` and the driver implementation do in fact **support both RGB and MIPI-DSI interfaces**.

## Solution

The fix ensures that when **either** `ESP_PANEL_DRIVERS_BUS_ENABLE_RGB` **or** `ESP_PANEL_DRIVERS_BUS_ENABLE_MIPI_DSI` is defined, the driver will initialize properly. This allows the **ST7701 driver** to work with **MIPI-DSI interfaces**, particularly on **ESP32-P4** platforms.

## Testing

* Code compiles successfully
* Runtime tested on **ESP32-P4** with **MIPI-DSI** interface
