### PR TITLE
Inverted colors for Waveshare ESP32 S3 1.85 (non-C)

### DIFF
--- a/src/board/supported/waveshare/BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_1_85.h
+++ b/src/board/supported/waveshare/BOARD_WAVESHARE_ESP32_S3_TOUCH_LCD_1_85.h
@@ -100,7 +100,7 @@
 #define ESP_PANEL_BOARD_LCD_COLOR_BITS          (ESP_PANEL_LCD_COLOR_BITS_RGB565)
                                                         // ESP_PANEL_LCD_COLOR_BITS_RGB565/RGB666/RGB888
 #define ESP_PANEL_BOARD_LCD_COLOR_BGR_ORDER     (0)     // 0: RGB, 1: BGR
-#define ESP_PANEL_BOARD_LCD_COLOR_INEVRT_BIT    (0)     // 0/1
+#define ESP_PANEL_BOARD_LCD_COLOR_INEVRT_BIT    (1)     // 0/1
 
 /**
  * @brief LCD transformation configuration


### PR DESCRIPTION
I probably made a mistake when creating the configuration file for this board, colors are inverted (and also swapped requiring the use of `lv_draw_sw_rgb565_swap` in flush callbacks, for example).

I cannot seem to resolve the bit swap via the configuration file, but the inversion is required and works.