### PR TITLE
a fix for build with Arduino ESP32 Core 3.3.4

### DIFF
--- a/src/drivers/bus/esp_panel_bus_dsi.cpp
+++ b/src/drivers/bus/esp_panel_bus_dsi.cpp
@@ -27,7 +27,7 @@ void BusDSI::Config::convertPartialToFull()
         host = HostFullConfig{
             .bus_id = HOST_ID_DEFAULT,
             .num_data_lanes = static_cast<uint8_t>(config.num_data_lanes),
-            .phy_clk_src = static_cast<mipi_dsi_phy_pllref_clock_source_t>(MIPI_DSI_PHY_CLK_SRC_DEFAULT),
+            .phy_clk_src = static_cast<mipi_dsi_phy_clock_source_t>(MIPI_DSI_PHY_CLK_SRC_DEFAULT),
             .lane_bit_rate_mbps = static_cast<uint32_t>(config.lane_bit_rate_mbps),
         };
     }

--- a/src/drivers/bus/esp_panel_bus_dsi.cpp
+++ b/src/drivers/bus/esp_panel_bus_dsi.cpp
@@ -27,7 +27,7 @@ void BusDSI::Config::convertPartialToFull()
         host = HostFullConfig{
             .bus_id = HOST_ID_DEFAULT,
             .num_data_lanes = static_cast<uint8_t>(config.num_data_lanes),
-            .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
+            .phy_clk_src = static_cast<mipi_dsi_phy_pllref_clock_source_t>(MIPI_DSI_PHY_CLK_SRC_DEFAULT),
             .lane_bit_rate_mbps = static_cast<uint32_t>(config.lane_bit_rate_mbps),
         };
     }


### PR DESCRIPTION
Build with recent [Arduino ESP32 Core 3.3.4](https://github.com/espressif/arduino-esp32/releases/tag/3.3.4) gives a failure.

```
In file included from /home/codespace/.arduino15/packages/esp32/tools/esp32-arduino-libs/idf-release_v5.5-8410210c-v2/esp32p4/include/hal/include/hal/mipi_dsi_types.h:10,
                 from /home/codespace/.arduino15/packages/esp32/tools/esp32-arduino-libs/idf-release_v5.5-8410210c-v2/esp32p4/include/hal/esp32p4/include/hal/mipi_dsi_host_ll.h:14,
                 from /home/codespace/.arduino15/packages/esp32/tools/esp32-arduino-libs/idf-release_v5.5-8410210c-v2/esp32p4/include/hal/esp32p4/include/hal/mipi_dsi_ll.h:14,
                 from /home/codespace/Arduino/libraries/ESP32_Display_Panel-master/src/drivers/host/esp_panel_host_dsi.hpp:11,
                 from /home/codespace/Arduino/libraries/ESP32_Display_Panel-master/src/drivers/bus/esp_panel_bus_dsi.cpp:13:
/home/codespace/Arduino/libraries/ESP32_Display_Panel-master/src/drivers/bus/esp_panel_bus_dsi.cpp: In member function 'void esp_panel::drivers::BusDSI::Config::convertPartialToFull()':
/home/codespace/.arduino15/packages/esp32/tools/esp32-arduino-libs/idf-release_v5.5-8410210c-v2/esp32p4/include/soc/esp32p4/include/soc/clk_tree_defs.h:469:38: error: cannot convert 'soc_module_clk_t' to 'mipi_dsi_phy_pllref_clock_source_t' {aka 'soc_periph_mipi_dsi_phy_pllref_clk_src_t'} in initialization
  469 | #define MIPI_DSI_PHY_CLK_SRC_DEFAULT SOC_MOD_CLK_PLL_F20M
      |                                      ^~~~~~~~~~~~~~~~~~~~
      |                                      |
      |                                      soc_module_clk_t
/home/codespace/Arduino/libraries/ESP32_Display_Panel-master/src/drivers/bus/esp_panel_bus_dsi.cpp:30:28: note: in expansion of macro 'MIPI_DSI_PHY_CLK_SRC_DEFAULT'
   30 |             .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

This PR contains a proposed fix.

