### PR TITLE
board: add JC3248W535EN (ESP32-S3, AXS15231B QSPI 320x480)

### DIFF
--- a/src/board/supported/jingcai/BOARD_JC3248W535EN.h
+++ b/src/board/supported/jingcai/BOARD_JC3248W535EN.h
@@ -1,0 +1,188 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * @file   BOARD_JC3248W535EN.h
+ * @brief  Configuration file for JC3248W535EN (Guition "Cheap Black Display")
+ *         ESP32-S3 + AXS15231B (QSPI) 3.5" 320x480, capacitive touch (I2C)
+ * @note   CASET/RASET ignored by IC — only full-frame writes work.
+ *         Hardware rotation (MADCTL MV) also broken — use portrait mode.
+ */
+
+#pragma once
+
+// *INDENT-OFF*
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Please update the following macros to configure general panel /////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_BOARD_NAME                "JC:JC3248W535EN"
+
+#define ESP_PANEL_BOARD_WIDTH               (320)
+#define ESP_PANEL_BOARD_HEIGHT              (480)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// LCD panel ////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_BOARD_USE_LCD             (1)
+
+#if ESP_PANEL_BOARD_USE_LCD
+
+#define ESP_PANEL_BOARD_LCD_CONTROLLER      AXS15231B
+
+#define ESP_PANEL_BOARD_LCD_BUS_TYPE        (ESP_PANEL_BUS_TYPE_QSPI)
+
+#if (ESP_PANEL_BOARD_LCD_BUS_TYPE == ESP_PANEL_BUS_TYPE_SPI) || \
+    (ESP_PANEL_BOARD_LCD_BUS_TYPE == ESP_PANEL_BUS_TYPE_QSPI)
+#define ESP_PANEL_BOARD_LCD_BUS_SKIP_INIT_HOST      (0)
+#endif
+
+#if ESP_PANEL_BOARD_LCD_BUS_TYPE == ESP_PANEL_BUS_TYPE_QSPI
+
+    /* QSPI bus */
+    #define ESP_PANEL_BOARD_LCD_QSPI_HOST_ID        (1)     // SPI2_HOST = 1
+#if !ESP_PANEL_BOARD_LCD_BUS_SKIP_INIT_HOST
+    #define ESP_PANEL_BOARD_LCD_QSPI_IO_SCK         (47)    // SCLK
+    #define ESP_PANEL_BOARD_LCD_QSPI_IO_DATA0       (21)    // DATA0 (MOSI/SIO0)
+    #define ESP_PANEL_BOARD_LCD_QSPI_IO_DATA1       (48)    // DATA1 (SIO1)
+    #define ESP_PANEL_BOARD_LCD_QSPI_IO_DATA2       (40)    // DATA2 (SIO2/WP)
+    #define ESP_PANEL_BOARD_LCD_QSPI_IO_DATA3       (39)    // DATA3 (SIO3/HOLD)
+#endif
+    #define ESP_PANEL_BOARD_LCD_QSPI_IO_CS          (45)    // CS
+    #define ESP_PANEL_BOARD_LCD_QSPI_MODE           (0)     // SPI mode 0
+    #define ESP_PANEL_BOARD_LCD_QSPI_CLK_HZ         (20 * 1000 * 1000)  // 20 MHz — 40 MHz also works (tested) but gives no fps gain; CPU is the bottleneck
+    #define ESP_PANEL_BOARD_LCD_QSPI_CMD_BITS       (32)    // AXS15231B QSPI: 32-bit command phase
+    #define ESP_PANEL_BOARD_LCD_QSPI_PARAM_BITS     (8)
+
+#endif // ESP_PANEL_BOARD_LCD_BUS_TYPE
+
+/* Vendor-specific init sequence from JC3248W535EN official demo (esp_bsp.c) */
+#define ESP_PANEL_BOARD_LCD_VENDOR_INIT_CMD()                                                   \
+    {                                                                                           \
+    {0xBB, (uint8_t []){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5A, 0xA5}, 8, 0},               \
+    {0xA0, (uint8_t []){0xC0, 0x10, 0x00, 0x02, 0x00, 0x00, 0x04, 0x3F, 0x20, 0x05, 0x3F, 0x3F, 0x00, 0x00, 0x00, 0x00, 0x00}, 17, 0}, \
+    {0xA2, (uint8_t []){0x30, 0x3C, 0x24, 0x14, 0xD0, 0x20, 0xFF, 0xE0, 0x40, 0x19, 0x80, 0x80, 0x80, 0x20, 0xf9, 0x10, 0x02, 0xff, 0xff, 0xF0, 0x90, 0x01, 0x32, 0xA0, 0x91, 0xE0, 0x20, 0x7F, 0xFF, 0x00, 0x5A}, 31, 0}, \
+    {0xD0, (uint8_t []){0xE0, 0x40, 0x51, 0x24, 0x08, 0x05, 0x10, 0x01, 0x20, 0x15, 0x42, 0xC2, 0x22, 0x22, 0xAA, 0x03, 0x10, 0x12, 0x60, 0x14, 0x1E, 0x51, 0x15, 0x00, 0x8A, 0x20, 0x00, 0x03, 0x3A, 0x12}, 30, 0}, \
+    {0xA3, (uint8_t []){0xA0, 0x06, 0xAa, 0x00, 0x08, 0x02, 0x0A, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x55, 0x55}, 22, 0}, \
+    {0xC1, (uint8_t []){0x31, 0x04, 0x02, 0x02, 0x71, 0x05, 0x24, 0x55, 0x02, 0x00, 0x41, 0x00, 0x53, 0xFF, 0xFF, 0xFF, 0x4F, 0x52, 0x00, 0x4F, 0x52, 0x00, 0x45, 0x3B, 0x0B, 0x02, 0x0d, 0x00, 0xFF, 0x40}, 30, 0}, \
+    {0xC3, (uint8_t []){0x00, 0x00, 0x00, 0x50, 0x03, 0x00, 0x00, 0x00, 0x01, 0x80, 0x01}, 11, 0}, \
+    {0xC4, (uint8_t []){0x00, 0x24, 0x33, 0x80, 0x00, 0xea, 0x64, 0x32, 0xC8, 0x64, 0xC8, 0x32, 0x90, 0x90, 0x11, 0x06, 0xDC, 0xFA, 0x00, 0x00, 0x80, 0xFE, 0x10, 0x10, 0x00, 0x0A, 0x0A, 0x44, 0x50}, 29, 0}, \
+    {0xC5, (uint8_t []){0x18, 0x00, 0x00, 0x03, 0xFE, 0x3A, 0x4A, 0x20, 0x30, 0x10, 0x88, 0xDE, 0x0D, 0x08, 0x0F, 0x0F, 0x01, 0x3A, 0x4A, 0x20, 0x10, 0x10, 0x00}, 23, 0}, \
+    {0xC6, (uint8_t []){0x05, 0x0A, 0x05, 0x0A, 0x00, 0xE0, 0x2E, 0x0B, 0x12, 0x22, 0x12, 0x22, 0x01, 0x03, 0x00, 0x3F, 0x6A, 0x18, 0xC8, 0x22}, 20, 0}, \
+    {0xC7, (uint8_t []){0x50, 0x32, 0x28, 0x00, 0xa2, 0x80, 0x8f, 0x00, 0x80, 0xff, 0x07, 0x11, 0x9c, 0x67, 0xff, 0x24, 0x0c, 0x0d, 0x0e, 0x0f}, 20, 0}, \
+    {0xC9, (uint8_t []){0x33, 0x44, 0x44, 0x01}, 4, 0}, \
+    {0xCF, (uint8_t []){0x2C, 0x1E, 0x88, 0x58, 0x13, 0x18, 0x56, 0x18, 0x1E, 0x68, 0x88, 0x00, 0x65, 0x09, 0x22, 0xC4, 0x0C, 0x77, 0x22, 0x44, 0xAA, 0x55, 0x08, 0x08, 0x12, 0xA0, 0x08}, 27, 0}, \
+    {0xD5, (uint8_t []){0x40, 0x8E, 0x8D, 0x01, 0x35, 0x04, 0x92, 0x74, 0x04, 0x92, 0x74, 0x04, 0x08, 0x6A, 0x04, 0x46, 0x03, 0x03, 0x03, 0x03, 0x82, 0x01, 0x03, 0x00, 0xE0, 0x51, 0xA1, 0x00, 0x00, 0x00}, 30, 0}, \
+    {0xD6, (uint8_t []){0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE, 0x93, 0x00, 0x01, 0x83, 0x07, 0x07, 0x00, 0x07, 0x07, 0x00, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x00, 0x84, 0x00, 0x20, 0x01, 0x00}, 30, 0}, \
+    {0xD7, (uint8_t []){0x03, 0x01, 0x0b, 0x09, 0x0f, 0x0d, 0x1E, 0x1F, 0x18, 0x1d, 0x1f, 0x19, 0x40, 0x8E, 0x04, 0x00, 0x20, 0xA0, 0x1F}, 19, 0}, \
+    {0xD8, (uint8_t []){0x02, 0x00, 0x0a, 0x08, 0x0e, 0x0c, 0x1E, 0x1F, 0x18, 0x1d, 0x1f, 0x19}, 12, 0}, \
+    {0xD9, (uint8_t []){0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F}, 12, 0}, \
+    {0xDD, (uint8_t []){0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F}, 12, 0}, \
+    {0xDF, (uint8_t []){0x44, 0x73, 0x4B, 0x69, 0x00, 0x0A, 0x02, 0x90}, 8, 0}, \
+    {0xE0, (uint8_t []){0x3B, 0x28, 0x10, 0x16, 0x0c, 0x06, 0x11, 0x28, 0x5c, 0x21, 0x0D, 0x35, 0x13, 0x2C, 0x33, 0x28, 0x0D}, 17, 0}, \
+    {0xE1, (uint8_t []){0x37, 0x28, 0x10, 0x16, 0x0b, 0x06, 0x11, 0x28, 0x5C, 0x21, 0x0D, 0x35, 0x14, 0x2C, 0x33, 0x28, 0x0F}, 17, 0}, \
+    {0xE2, (uint8_t []){0x3B, 0x07, 0x12, 0x18, 0x0E, 0x0D, 0x17, 0x35, 0x44, 0x32, 0x0C, 0x14, 0x14, 0x36, 0x3A, 0x2F, 0x0D}, 17, 0}, \
+    {0xE3, (uint8_t []){0x37, 0x07, 0x12, 0x18, 0x0E, 0x0D, 0x17, 0x35, 0x44, 0x32, 0x0C, 0x14, 0x14, 0x36, 0x32, 0x2F, 0x0F}, 17, 0}, \
+    {0xE4, (uint8_t []){0x3B, 0x07, 0x12, 0x18, 0x0E, 0x0D, 0x17, 0x39, 0x44, 0x2E, 0x0C, 0x14, 0x14, 0x36, 0x3A, 0x2F, 0x0D}, 17, 0}, \
+    {0xE5, (uint8_t []){0x37, 0x07, 0x12, 0x18, 0x0E, 0x0D, 0x17, 0x39, 0x44, 0x2E, 0x0C, 0x14, 0x14, 0x36, 0x3A, 0x2F, 0x0F}, 17, 0}, \
+    {0xA4, (uint8_t []){0x85, 0x85, 0x95, 0x82, 0xAF, 0xAA, 0xAA, 0x80, 0x10, 0x30, 0x40, 0x40, 0x20, 0xFF, 0x60, 0x30}, 16, 0}, \
+    {0xA4, (uint8_t []){0x85, 0x85, 0x95, 0x85}, 4, 0}, \
+    {0xBB, (uint8_t []){0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 8, 0}, \
+    {0x13, (uint8_t []){0x00}, 0, 0}, \
+    {0x11, (uint8_t []){0x00}, 0, 120}, \
+    {0x2C, (uint8_t []){0x00, 0x00, 0x00, 0x00}, 4, 0}, \
+    }
+
+#define ESP_PANEL_BOARD_LCD_COLOR_BITS          (ESP_PANEL_LCD_COLOR_BITS_RGB565)
+#define ESP_PANEL_BOARD_LCD_COLOR_BGR_ORDER     (0)     // RGB order
+#define ESP_PANEL_BOARD_LCD_COLOR_INEVRT_BIT    (0)
+
+#define ESP_PANEL_BOARD_LCD_SWAP_XY             (0)     // HW rotation broken — use portrait
+#define ESP_PANEL_BOARD_LCD_MIRROR_X            (0)
+#define ESP_PANEL_BOARD_LCD_MIRROR_Y            (0)
+#define ESP_PANEL_BOARD_LCD_GAP_X               (0)
+#define ESP_PANEL_BOARD_LCD_GAP_Y               (0)
+
+#define ESP_PANEL_BOARD_LCD_RST_IO              (-1)    // No reset pin on this board
+#define ESP_PANEL_BOARD_LCD_RST_LEVEL           (0)
+
+#endif // ESP_PANEL_BOARD_USE_LCD
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Touch panel //////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_BOARD_USE_TOUCH               (1)
+
+#if ESP_PANEL_BOARD_USE_TOUCH
+
+#define ESP_PANEL_BOARD_TOUCH_CONTROLLER        AXS15231B
+
+#define ESP_PANEL_BOARD_TOUCH_BUS_TYPE          (ESP_PANEL_BUS_TYPE_I2C)
+
+#if (ESP_PANEL_BOARD_TOUCH_BUS_TYPE == ESP_PANEL_BUS_TYPE_I2C) || \
+    (ESP_PANEL_BOARD_TOUCH_BUS_TYPE == ESP_PANEL_BUS_TYPE_SPI)
+#define ESP_PANEL_BOARD_TOUCH_BUS_SKIP_INIT_HOST        (0)
+#endif
+
+#if ESP_PANEL_BOARD_TOUCH_BUS_TYPE == ESP_PANEL_BUS_TYPE_I2C
+
+    #define ESP_PANEL_BOARD_TOUCH_I2C_HOST_ID           (0)     // I2C0
+#if !ESP_PANEL_BOARD_TOUCH_BUS_SKIP_INIT_HOST
+    #define ESP_PANEL_BOARD_TOUCH_I2C_CLK_HZ            (400 * 1000)
+    #define ESP_PANEL_BOARD_TOUCH_I2C_SCL_PULLUP        (1)
+    #define ESP_PANEL_BOARD_TOUCH_I2C_SDA_PULLUP        (1)
+    #define ESP_PANEL_BOARD_TOUCH_I2C_IO_SCL            (8)     // GPIO 8 (shared with LCD DC in QSPI mode)
+    #define ESP_PANEL_BOARD_TOUCH_I2C_IO_SDA            (4)
+#endif
+    #define ESP_PANEL_BOARD_TOUCH_I2C_ADDRESS           (0)     // Use default AXS15231B touch address
+
+#endif // ESP_PANEL_BOARD_TOUCH_BUS_TYPE
+
+#define ESP_PANEL_BOARD_TOUCH_SWAP_XY           (0)
+#define ESP_PANEL_BOARD_TOUCH_MIRROR_X          (0)
+#define ESP_PANEL_BOARD_TOUCH_MIRROR_Y          (0)
+
+#define ESP_PANEL_BOARD_TOUCH_RST_IO            (-1)
+#define ESP_PANEL_BOARD_TOUCH_RST_LEVEL         (0)
+#define ESP_PANEL_BOARD_TOUCH_INT_IO            (-1)
+#define ESP_PANEL_BOARD_TOUCH_INT_LEVEL         (0)
+
+#endif // ESP_PANEL_BOARD_USE_TOUCH
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Backlight ////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_BOARD_USE_BACKLIGHT           (1)
+
+#if ESP_PANEL_BOARD_USE_BACKLIGHT
+
+#define ESP_PANEL_BOARD_BACKLIGHT_TYPE          (ESP_PANEL_BACKLIGHT_TYPE_PWM_LEDC)
+
+#if (ESP_PANEL_BOARD_BACKLIGHT_TYPE == ESP_PANEL_BACKLIGHT_TYPE_SWITCH_GPIO) || \
+    (ESP_PANEL_BOARD_BACKLIGHT_TYPE == ESP_PANEL_BACKLIGHT_TYPE_SWITCH_EXPANDER) || \
+    (ESP_PANEL_BOARD_BACKLIGHT_TYPE == ESP_PANEL_BACKLIGHT_TYPE_PWM_LEDC)
+
+    #define ESP_PANEL_BOARD_BACKLIGHT_IO        (1)     // GPIO 1
+    #define ESP_PANEL_BOARD_BACKLIGHT_ON_LEVEL  (1)
+
+#endif
+
+#define ESP_PANEL_BOARD_BACKLIGHT_IDLE_OFF      (0)
+
+#endif // ESP_PANEL_BOARD_USE_BACKLIGHT
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////// IO Expander //////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_BOARD_USE_EXPANDER            (0)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////// File Version ///////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP_PANEL_BOARD_CUSTOM_FILE_VERSION_MAJOR 1
+#define ESP_PANEL_BOARD_CUSTOM_FILE_VERSION_MINOR 0
+#define ESP_PANEL_BOARD_CUSTOM_FILE_VERSION_PATCH 0
+
+// *INDENT-ON*


### PR DESCRIPTION
## Summary

Adds board configuration for the **Jingcai JC3248W535EN** development board.

### Hardware
- MCU: ESP32-S3, 16 MB flash, 8 MB Octal PSRAM
- Display: 3.2" 320×480 IPS, AXS15231B controller, QSPI
- Touch: AXS15231B I2C, SCL=GPIO8, SDA=GPIO4, addr=0x3B

### Key fixes vs default AXS15231B configuration

**Vendor init sequence is mandatory.**
The default library init sequence includes command `0x22` (ALL_PIXELS_OFF) which results in a blank or corrupted display. This PR uses the full init sequence from the vendor's official Arduino demo (`esp_bsp.c`). The sequence must end with `0x2C` (RAMWR), not `0x29` (DISPLAY_ON).

**QSPI clock at 20 MHz.**
The QSPI pins on this board route through the ESP32-S3 GPIO matrix. 40 MHz is electrically stable but provides no fps improvement (CPU is the bottleneck in draw_bitmap, not bus bandwidth), so 20 MHz is used for margin.

**Touch pin correction.**
SCL=GPIO8, SDA=GPIO4 (corrected from library defaults).

### Testing
Tested with MicroPython firmware on the physical board. Display initialises correctly, touch reports coordinates, full-frame RGB565 updates work.